### PR TITLE
remove all linters but cppcheck

### DIFF
--- a/fastrtps_cmake_module/CMakeLists.txt
+++ b/fastrtps_cmake_module/CMakeLists.txt
@@ -7,11 +7,6 @@ find_package(ament_cmake REQUIRED)
 #list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 #find_package(FastRTPS MODULE)
 
-if(AMENT_ENABLE_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
 ament_package(
   CONFIG_EXTRAS "fastrtps_cmake_module-extras.cmake"
 )

--- a/fastrtps_cmake_module/package.xml
+++ b/fastrtps_cmake_module/package.xml
@@ -8,9 +8,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rmw_fastrtps_cpp/CMakeLists.txt
+++ b/rmw_fastrtps_cpp/CMakeLists.txt
@@ -39,8 +39,8 @@ ament_export_libraries(rmw_fastrtps_cpp fastcdr fastrtps)
 register_rmw_implementation("rosidl_typesupport_introspection_cpp")
 
 if(AMENT_ENABLE_TESTING)
-    find_package(ament_lint_auto REQUIRED)
-    ament_lint_auto_find_test_dependencies()
+    find_package(ament_cmake_cppcheck REQUIRED)
+    ament_cppcheck()
 endif()
 
 ament_package()

--- a/rmw_fastrtps_cpp/package.xml
+++ b/rmw_fastrtps_cpp/package.xml
@@ -20,8 +20,7 @@
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This will fix the failing linter tests in the `rmw_fastrtps_cpp` package (http://ci.ros2.org/job/ros2_batch_ci_linux/389/testReport/).