### PR TITLE
Explicit downcast of type size

### DIFF
--- a/rmw_fastrtps_cpp/src/MessageTypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/MessageTypeSupport.cpp
@@ -21,7 +21,7 @@ MessageTypeSupport::MessageTypeSupport(const rosidl_typesupport_introspection_cp
     setName(strdup(name.c_str()));
 
     if(members->member_count_ != 0)
-        m_typeSize = calculateMaxSerializedSize(members, 0);
+        m_typeSize = static_cast<uint32_t>(calculateMaxSerializedSize(members, 0));
     else
         m_typeSize = 1;
 }


### PR DESCRIPTION
Avoid Windows compiler warning by making the 64->32 bit downcast explicit.