### PR TITLE
Fix memory leak on Windows

### DIFF
--- a/rmw_fastrtps_cpp/src/MessageTypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/MessageTypeSupport.cpp
@@ -18,7 +18,7 @@ MessageTypeSupport::MessageTypeSupport(const rosidl_typesupport_introspection_cp
         typeTooLarge_ = true;
 
     std::string name = std::string(members->package_name_) + "::msg::dds_::" + members->message_name_ + "_";
-    setName(strdup(name.c_str()));
+    setName(name.c_str());
 
     if(members->member_count_ != 0)
         m_typeSize = static_cast<uint32_t>(calculateMaxSerializedSize(members, 0));

--- a/rmw_fastrtps_cpp/src/ServiceTypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/ServiceTypeSupport.cpp
@@ -21,10 +21,10 @@ RequestTypeSupport::RequestTypeSupport(const rosidl_typesupport_introspection_cp
         typeTooLarge_ = true;
 
     std::string name = std::string(members->package_name_) + "::srv::dds_::" + members->service_name_ + "_Request_";
-    setName(strdup(name.c_str()));
+    setName(name.c_str());
 
     if(members_->member_count_ != 0)
-        m_typeSize = calculateMaxSerializedSize(members_, 0);
+        m_typeSize = static_cast<uint32_t>(calculateMaxSerializedSize(members_, 0));
     else
         m_typeSize = 1;
 }
@@ -35,10 +35,10 @@ ResponseTypeSupport::ResponseTypeSupport(const rosidl_typesupport_introspection_
     members_ = members->response_members_;
 
     std::string name = std::string(members->package_name_) + "::srv::dds_::" + members->service_name_ + "_Response_";
-    setName(strdup(name.c_str()));
+    setName(name.c_str());
 
     if(members_->member_count_ != 0)
-        m_typeSize = calculateMaxSerializedSize(members_, 0);
+        m_typeSize = static_cast<uint32_t>(calculateMaxSerializedSize(members_, 0));
     else
         m_typeSize = 1;
 }


### PR DESCRIPTION
Unfortunately Windows throws a compiler warning when it sees strdup(); it wants to see _strdup() instead.