### PR TITLE
stub functions for wait_for_service

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -1751,6 +1751,23 @@ fail:
         RMW_SET_ERROR_MSG("not implemented");
         return RMW_RET_ERROR;
     }
+
+    rmw_ret_t
+    rmw_service_server_is_available(
+      const rmw_node_t * node,
+      const rmw_client_t * client,
+      bool * is_available)
+    {
+      RMW_SET_ERROR_MSG("not implemented");
+      return RMW_RET_ERROR;
+    }
+
+    const rmw_guard_condition_t *
+    rmw_node_get_graph_guard_condition(const rmw_node_t * node)
+    {
+      RMW_SET_ERROR_MSG("not implemented");
+      return (const rmw_guard_condition_t *)0xf;
+    }
 }
 
 rmw_ret_t


### PR DESCRIPTION
This is needed so that rcl can compile. All the code which uses this downstream is configured to not test this code (which just raises 'not implemented').

Connects to ros2/ros2#215