### PR TITLE
fix warnings on Windows

### DIFF
--- a/rmw_fastrtps_cpp/src/TypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/TypeSupport.cpp
@@ -246,7 +246,7 @@ bool TypeSupport::serializeROSmessage(eprosima::fastcdr::Cdr &ser, const rosidl_
                         // Control maximum length.
                         if((member->string_upper_bound_ && str.length() > member->string_upper_bound_ + 1) || str.length() > 256)
                         {
-                            printf("string overcomes the maximum length with length %lu\n", str.length());
+                            printf("string overcomes the maximum length with length %zu\n", str.length());
                             throw std::runtime_error("string overcomes the maximum length");
                         }
                         ser << str;

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -301,7 +301,7 @@ extern "C"
         FastRTPSNodeImpl * node_impl = nullptr;
         try {
             node_impl = new FastRTPSNodeImpl();
-        } catch(std::bad_alloc & exc) {
+        } catch(std::bad_alloc) {
             RMW_SET_ERROR_MSG("failed to allocate node impl struct");
             return NULL;
         }


### PR DESCRIPTION
See http://ci.ros2.org/job/ci_windows/1395/warnings34Result/fixed/

No regressions on the other platforms:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1383)](http://ci.ros2.org/job/ci_linux/1383/)
* OS X [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1080)](http://ci.ros2.org/job/ci_osx/1080/)

See related changes eProsima/Fast-RTPS#43