### PR TITLE
make serialization of bool values more robust against uninitialized values

### DIFF
--- a/rmw_fastrtps_cpp/src/TypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/TypeSupport.cpp
@@ -202,8 +202,10 @@ bool TypeSupport::serializeROSmessage(eprosima::fastcdr::Cdr &ser, const rosidl_
             {
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
                     {
-                        bool sb = false, &b = *(bool*)field;
-                        if(b) sb = true; 
+                        bool sb = false;
+                        // don't cast to bool here because if the bool is
+                        // uninitialized the random value can't be deserialized
+                        if(*(uint8_t*)field) sb = true;
                         ser << sb;
                     }
                     break;


### PR DESCRIPTION
Linux:
* before: http://ci.ros2.org/job/ci_linux/1390/testReport/
* after: http://ci.ros2.org/job/ci_linux/1391/testReport/
* -16 failing tests

OS X:
* before: http://ci.ros2.org/job/ci_osx/1085/testReport/
* after: http://ci.ros2.org/job/ci_osx/1086/testReport/
* -13 failing tests

The uninitialized values should be addressed too but they are coming from our code, e.g. `rclcpp::ParameterVariant`.