### PR TITLE
fix compiler warning on windows

### DIFF
--- a/rmw_fastrtps_cpp/src/TypeSupport.cpp
+++ b/rmw_fastrtps_cpp/src/TypeSupport.cpp
@@ -22,7 +22,7 @@ static inline void*
 align_(size_t __align, size_t __size, void*& __ptr, size_t& __space) noexcept
 {
     const auto __intptr = reinterpret_cast<uintptr_t>(__ptr);
-    const auto __aligned = (__intptr - 1u + __align) & -__align;
+    const auto __aligned = (__intptr - 1u + __align) & ~(__align - 1);
     const auto __diff = __aligned - __intptr;
     if ((__size + __diff) > __space)
         return nullptr;


### PR DESCRIPTION
unary minus on an unsigned int gives a compiler warning in windows.