### PR TITLE
Participant lease duration set to default.

### DIFF
--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -281,7 +281,6 @@ extern "C"
 
         ParticipantAttributes participantParam;
         participantParam.rtps.builtin.domainId = static_cast<uint32_t>(domain_id);
-        participantParam.rtps.builtin.leaseDuration = c_TimeInfinite;
         participantParam.rtps.setName(name);
 
         Participant *participant = Domain::createParticipant(participantParam);


### PR DESCRIPTION
@dirk-thomas It solves the communication error between OpenSplice and FastRTPS using
localhost interface on Mac OSX. For an unknown reason, OpenSplice doesn't response our ACKs when our participant has the lease duration set to infinitive.