### PR TITLE
use dynamical memory allocation to allow large, unbounded messages

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.h
@@ -38,10 +38,9 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(const MembersType *members)
     std::string name = std::string(members->package_name_) + "::msg::dds_::" + members->message_name_ + "_";
     this->setName(name.c_str());
 
-    if(members->member_count_ != 0)
-        this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 0));
-    else
-        this->m_typeSize = 1;
+    // TODO(wjwwood): this could be more intelligent, setting m_typeSize to the
+    // maximum serialized size of the message, when the message is a bonded one.
+    this->m_typeSize = 0;
 }
 
 #endif // _RMW_FASTRTPS_CPP_MESSAGETYPESUPPORT_IMPL_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.h
@@ -93,20 +93,14 @@ namespace rmw_fastrtps_cpp
         }
     };
 
-    typedef struct Buffer
-    {
-        uint32_t length;
-        char *pointer;
-    } Buffer;
-
     template <typename MembersType>
     class TypeSupport : public eprosima::fastrtps::TopicDataType
     {
         public:
 
-            bool serializeROSmessage(const void *ros_message, Buffer *data);
+            bool serializeROSmessage(const void *ros_message, eprosima::fastcdr::FastBuffer *data);
 
-            bool deserializeROSmessage(const Buffer* data, void *ros_message);
+            bool deserializeROSmessage(eprosima::fastcdr::FastBuffer *data, void *ros_message);
 
             bool serialize(void *data, SerializedPayload_t *payload);
 

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
@@ -60,7 +60,7 @@ template <typename MembersType>
 void TypeSupport<MembersType>::deleteData(void* data)
 {
     assert(data);
-    free(data);
+    delete static_cast<eprosima::fastcdr::FastBuffer *>(data);
 }
 
 static inline void*
@@ -228,17 +228,12 @@ template<typename T>
 void serialize_array(
     const rosidl_typesupport_introspection_cpp::MessageMember * member,
     void * field,
-    eprosima::fastcdr::Cdr &ser,
-    bool typeTooLarge)
+    eprosima::fastcdr::Cdr &ser)
 {
     if (member->array_size_ && !member->is_upper_bound_) {
         ser.serializeArray((T*)field, member->array_size_);
     } else {
         std::vector<T> & data = *reinterpret_cast<std::vector<T> *>(field);
-        if(data.size() > (member->is_upper_bound_ ? member->array_size_ : (typeTooLarge ? 30 : 101))) {
-            printf("vector overcomes the maximum length\n");
-            throw std::runtime_error("vector overcomes the maximum length");
-        }
         ser << data;
     }
 }
@@ -248,17 +243,12 @@ template<typename T>
 void serialize_array(
     const rosidl_typesupport_introspection_c__MessageMember * member,
     void * field,
-    eprosima::fastcdr::Cdr &ser,
-    bool typeTooLarge)
+    eprosima::fastcdr::Cdr &ser)
 {
     if (member->array_size_ && !member->is_upper_bound_) {
         ser.serializeArray((T*)field, member->array_size_);
     } else {
         auto & data = *reinterpret_cast<typename GenericCArray<T>::type *>(field);
-        if(data.size > (member->is_upper_bound_ ? member->array_size_ : (typeTooLarge ? 30 : 101))) {
-            printf("vector overcomes the maximum length\n");
-            throw std::runtime_error("vector overcomes the maximum length");
-        }
         ser.serializeArray((T*)data.data, data.size);
     }
 }
@@ -267,8 +257,7 @@ template<>
 void serialize_array<std::string>(
     const rosidl_typesupport_introspection_c__MessageMember * member,
     void * field,
-    eprosima::fastcdr::Cdr &ser,
-    bool typeTooLarge)
+    eprosima::fastcdr::Cdr &ser)
 {
     using CStringHelper = StringHelper<rosidl_typesupport_introspection_c__MessageMembers>;
     // First, cast field to rosidl_generator_c
@@ -278,11 +267,6 @@ void serialize_array<std::string>(
         ser.serializeArray(string_field->data, member->array_size_);
     } else {
         auto & string_array_field = *reinterpret_cast<rosidl_generator_c__String__Array *>(field);
-        if(
-            string_array_field.size > (member->is_upper_bound_ ? member->array_size_ : (typeTooLarge ? 30 : 101))) {
-            printf("vector overcomes the maximum length\n");
-            throw std::runtime_error("vector overcomes the maximum length");
-        }
         std::vector<std::string> cpp_string_vector;
         for (size_t i = 0; i < string_array_field.size; ++i) {
           cpp_string_vector.push_back(CStringHelper::convert_to_std_string(string_array_field.data[i]));
@@ -408,42 +392,42 @@ bool TypeSupport<MembersType>::serializeROSmessage(
             switch(member->type_id_)
             {
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
-                    serialize_array<bool>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<bool>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-                    serialize_array<uint8_t>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<uint8_t>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
-                    serialize_array<char>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<char>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
-                    serialize_array<float>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<float>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
-                    serialize_array<double>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<double>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
-                    serialize_array<int16_t>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<int16_t>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
-                    serialize_array<uint16_t>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<uint16_t>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
-                    serialize_array<int32_t>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<int32_t>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
-                    serialize_array<uint32_t>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<uint32_t>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
-                    serialize_array<int64_t>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<int64_t>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
-                    serialize_array<uint64_t>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<uint64_t>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
-                    serialize_array<std::string>(member, field, ser, typeByDefaultLarge());
+                    serialize_array<std::string>(member, field, ser);
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
                     {
@@ -832,32 +816,29 @@ size_t TypeSupport<MembersType>::calculateMaxSerializedSize(
 
 template <typename MembersType>
 bool TypeSupport<MembersType>::serializeROSmessage(
-    const void *ros_message, Buffer *buffer)
+    const void *ros_message, eprosima::fastcdr::FastBuffer *buffer)
 {
     assert(buffer);
     assert(ros_message);
 
-    eprosima::fastcdr::FastBuffer fastbuffer(buffer->pointer, m_typeSize);
-    eprosima::fastcdr::Cdr ser(fastbuffer);
+    eprosima::fastcdr::Cdr ser(*buffer);
 
     if(members_->member_count_ != 0)
         TypeSupport::serializeROSmessage(ser, members_, ros_message);
     else
         ser << (uint8_t)0;
 
-    buffer->length = (uint32_t)ser.getSerializedDataLength();
     return true;
 }
 
 template <typename MembersType>
 bool TypeSupport<MembersType>::deserializeROSmessage(
-    const Buffer* buffer, void *ros_message)
+    eprosima::fastcdr::FastBuffer* buffer, void *ros_message)
 {
     assert(buffer);
     assert(ros_message);
 
-    eprosima::fastcdr::FastBuffer fastbuffer(buffer->pointer, buffer->length);
-    eprosima::fastcdr::Cdr deser(fastbuffer);
+    eprosima::fastcdr::Cdr deser(*buffer);
 
     if(members_->member_count_ != 0)
         TypeSupport::deserializeROSmessage(deser, members_, ros_message, false);
@@ -874,15 +855,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
 template <typename MembersType>
 void* TypeSupport<MembersType>::createData()
 {
-    Buffer *buffer = static_cast<Buffer*>(malloc(sizeof(Buffer) + m_typeSize));
-
-    if(buffer)
-    {
-        buffer->length = 0;
-        buffer->pointer = (char*)(buffer + 1);
-    }
-
-    return buffer;
+    return new eprosima::fastcdr::FastBuffer();
 }
 
 template <typename MembersType>
@@ -892,10 +865,11 @@ bool TypeSupport<MembersType>::serialize(
     assert(data);
     assert(payload);
 
-    Buffer *buffer = static_cast<Buffer*>(data);
-    payload->length = buffer->length;
+    eprosima::fastcdr::FastBuffer *buffer = static_cast<eprosima::fastcdr::FastBuffer*>(data);
+    payload->length = buffer->getBufferSize();
     payload->encapsulation = CDR_LE;
-    memcpy(payload->data, buffer->pointer, buffer->length);
+    payload->reserve(buffer->getBufferSize());
+    memcpy(payload->data, buffer->getBuffer(), buffer->getBufferSize());
     return true;
 }
 
@@ -905,9 +879,9 @@ bool TypeSupport<MembersType>::deserialize(SerializedPayload_t *payload, void *d
     assert(data);
     assert(payload);
 
-    Buffer *buffer = static_cast<Buffer*>(data);
-    buffer->length = payload->length;
-    memcpy(buffer->pointer, payload->data, payload->length);
+    eprosima::fastcdr::FastBuffer *buffer = static_cast<eprosima::fastcdr::FastBuffer*>(data);
+    buffer->resize(payload->length);
+    memcpy(buffer->getBuffer(), payload->data, payload->length);
     return true;
 }
 


### PR DESCRIPTION
This uses the proposed `publisherParam.allowPayloadResize` option (as true) to allow dynamic resizing of the serialized payloads and therefore allowing large unbounded message types by allow us to set `m_typeSize` to 0.

Closes #36.