### PR TITLE
Use a universal reference to avoid extra std::string copies

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
@@ -381,7 +381,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
                     break;
                 case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
                     {
-                        auto str = StringHelper<MembersType>::convert_to_std_string(field);
+                        auto && str = StringHelper<MembersType>::convert_to_std_string(field);
 
                         // Control maximum length.
                         if((member->string_upper_bound_ && str.length() > member->string_upper_bound_ + 1) || str.length() > 256)


### PR DESCRIPTION
@jacquelinekay I noticed that the universal reference was removed when https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/pull/27 was merged, I don't know if it was causing any issues on the buildfarm, I checked locally and it seems to work fine.

Alternatively, I also pushed #50, which accomplishes the same but without using universal references, in case the universal reference were causing trouble.