### PR TITLE
Use new api

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport_impl.h
@@ -41,7 +41,7 @@ MessageTypeSupport<MembersType>::MessageTypeSupport(const MembersType *members)
     if(members->member_count_ != 0)
         this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(members, 0));
     else
-        this->m_typeSize = 1;
+        this->m_typeSize = 4;
 }
 
 #endif // _RMW_FASTRTPS_CPP_MESSAGETYPESUPPORT_IMPL_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport_impl.h
@@ -45,7 +45,7 @@ RequestTypeSupport<ServiceMembersType, MessageMembersType>::RequestTypeSupport(c
     if(this->members_->member_count_ != 0)
         this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
     else
-        this->m_typeSize = 1;
+        this->m_typeSize = 4;
 }
 
 template <typename ServiceMembersType, typename MessageMembersType>
@@ -60,7 +60,7 @@ ResponseTypeSupport<ServiceMembersType, MessageMembersType>::ResponseTypeSupport
     if(this->members_->member_count_ != 0)
         this->m_typeSize = static_cast<uint32_t>(this->calculateMaxSerializedSize(this->members_, 0));
     else
-        this->m_typeSize = 1;
+        this->m_typeSize = 4;
 }
 
 #endif // _RMW_FASTRTPS_CPP_SERVICETYPESUPPORT_IMPL_H_

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.h
@@ -112,6 +112,8 @@ namespace rmw_fastrtps_cpp
 
             bool deserialize(SerializedPayload_t *payload, void *data);
 
+            std::function<uint32_t()> getSerializedSizeProvider(void* data);
+
             void* createData();
 
             void deleteData(void* data);

--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
@@ -911,4 +911,13 @@ bool TypeSupport<MembersType>::deserialize(SerializedPayload_t *payload, void *d
     return true;
 }
 
+template <typename MembersType>
+std::function<uint32_t()> TypeSupport<MembersType>::getSerializedSizeProvider(void* data)
+{
+  assert(data);
+
+  eprosima::fastcdr::Cdr *ser = static_cast<eprosima::fastcdr::Cdr*>(data);
+  return [ser]() -> uint32_t { return ser->getSerializedDataLength(); };
+}
+
 #endif // _RMW_FASTRTPS_CPP_TYPESUPPORT_IMPL_H_

--- a/rmw_fastrtps_cpp/src/functions.cpp
+++ b/rmw_fastrtps_cpp/src/functions.cpp
@@ -608,7 +608,7 @@ extern "C"
             return NULL;
         }
 
-        eprosima::Log::setVerbosity(eprosima::VERB_ERROR);
+        eprosima::fastrtps::Log::SetVerbosity(eprosima::fastrtps::Log::Error);
 
         ParticipantAttributes participantParam;
         participantParam.rtps.builtin.domainId = static_cast<uint32_t>(domain_id);


### PR DESCRIPTION
The Log API changed in eProsima/Fast-RTPS@f94ba23f40a8d669961786f540af09edd1ff1212.

The new method `TypeSupport::` was introduced in eProsima/Fast-RTPS#59. I am just not sure if calling `calculateMaxSerializedSize` is appropriate here.

While it makes it compile again (http://ci.ros2.org/job/ci_linux/1691/) it fails several tests due to the new size provider. @richiprosima Maybe you can advise what the correct way of implementing this is.
