### PR TITLE
do not artifically limit maximum string length

### DIFF
--- a/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
+++ b/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport_impl.h
@@ -430,7 +430,7 @@ bool TypeSupport<MembersType>::serializeROSmessage(
                         auto && str = StringHelper<MembersType>::convert_to_std_string(field);
 
                         // Control maximum length.
-                        if((member->string_upper_bound_ && str.length() > member->string_upper_bound_ + 1) || str.length() > 256)
+                        if(member->string_upper_bound_ && str.length() > member->string_upper_bound_ + 1)
                         {
                             throw std::runtime_error("string overcomes the maximum length");
                         }


### PR DESCRIPTION
Fixes #60.

Before:
* http://ci.ros2.org/job/ci_linux/1776/
* http://ci.ros2.org/job/ci_osx/1344/
* http://ci.ros2.org/job/ci_windows/1704/

After:
* http://ci.ros2.org/job/ci_linux/1777/
* http://ci.ros2.org/job/ci_osx/1345/
* http://ci.ros2.org/job/ci_windows/1705/